### PR TITLE
Bug 1093759 - Use fast-forward when landing from integration branch +autoland

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,25 @@
 # Autolander
 
-Autolander is a tool which manages continuous integration workflows between Bugzilla and Github. Autolander interacts between several components, some of which are:
+Autolander is a tool which manages continuous integration workflows between Bugzilla and Github. Autolander has several features including:
+
+* Automatic pull request to bugzilla attachment linking.
+* Integrates code for you once the bug has a R+ (from a suggested reviewer) and the checkin-needed keyword.
+* The integration step includes several processes, but here is a quick summary:
+  * Merges code to an integration branch.
+  * The commits are ordered in the order that they are meant to be landed in master.
+  * A taskgraph is submitted to taskcluster for each integration.
+  * If a taskgraph fails, the commit is discarded, and newer commits are re-run on the integration branch.
+  * On a successful taskgraph run, we fast-forward the base branch to the integration commit.
+  * If we can not fast-forward the base branch, we re-create the integration branch from the base branch and replay all integrations on top of it.
+* Autolander will update the bug with the landing commit, and resolve the bug as fixed.
+
+Validations:
+
+* Currently validates that we can find a bug number in the pull request title.
+* TODO: Validate that commits have bug numbers listed.
+* TBD: If we should require a r= in each commit message.
+
+Autolander interacts between several components, some of which are:
 
 * Bugzilla - Attaches pull requests and comments on bugs.
 * Github - Listens for webhooks, and lands code.
@@ -29,6 +48,10 @@ npm test
 
 # Run a single test:
 ./test/runone.sh test/some_test.js
+
+# Each test will automatically spin up the worker and web servers by default.
+# It can be useful to run these on your own for debugging purposes. Pass NO_SERVER=1 if you do this.
+NO_SERVER=1 npm test
 ```
 
 

--- a/lib/bug_store.js
+++ b/lib/bug_store.js
@@ -15,8 +15,8 @@ function partitionForBug(bugId) {
 }
 
 var AzureApi = function(config) {
-  // XXX: A local cache of bugs and taskgraphs we're currently running integration for.
-  this.activeBugs = [];
+  // XXX: A local cache of taskgraphs we're currently running integration for.
+  this.activeIntegrations = [];
   this.activeTaskGraphIds = {};
   this._config = config;
   return this;

--- a/lib/github.js
+++ b/lib/github.js
@@ -28,7 +28,7 @@ exports.init = function * (config) {
 exports.COMMENTS = {
   NO_BUG_FOUND: 'Autolander could not find a bug number in your pull request title. All pull requests should be in the format of: Bug [number] - [description].',
   NON_INTEGRABLE: 'The pull request could not be applied to the integration branch. Please try again after current integration is complete.',
-  CI_FAILED: 'The pull request failed to pass integration tests. It could not be landed in master, please try again.',
+  CI_FAILED: 'The pull request failed to pass integration tests. It could not be landed, please try again.',
   NOT_SUGGESTED_REVIEWER: 'Autolander could not locate a review from a user within the suggested reviewer list. Either the patch author or the reviewer should be in the suggested reviewer list.',
   TASKGRAPH_POST_ERROR: 'There was an error creating the taskgraph, please try again. If the issue persists please contact someone in #taskcluster.'
 };
@@ -146,13 +146,13 @@ exports.maybeCreateIntegrationBranch = function * (runtime, pull) {
     debug('creating integration branch', branchName);
 
     var getRef = thunkify(runtime.githubApi.gitdata.getReference.bind(runtime.githubApi.gitdata));
-    var masterRef = yield getRef({
+    var baseBranchRef = yield getRef({
       user: repoParts[0],
       repo: repoParts[1],
       ref: 'heads/' + pull.base.ref,
       token: runtime.config.githubConfig.token
     });
-    debug('got master ref', masterRef.object.sha);
+    debug('got base branch ref', pull.base.ref, baseBranchRef.object.sha);
 
     try {
       var createRef = thunkify(runtime.githubApi.gitdata.createReference.bind(runtime.githubApi.gitdata));
@@ -160,7 +160,7 @@ exports.maybeCreateIntegrationBranch = function * (runtime, pull) {
         user: repoParts[0],
         repo: repoParts[1],
         ref: 'refs/heads/' + branchName,
-        sha: masterRef.object.sha,
+        sha: baseBranchRef.object.sha,
         token: runtime.config.githubConfig.token
       });
       debug('created integration branch reference', ref.object.sha);

--- a/lib/taskgraph.js
+++ b/lib/taskgraph.js
@@ -237,9 +237,12 @@ exports.create = function * (runtime, bugId, pull) {
   var graphStatus = yield scheduler.createTaskGraph(id, graph);
   debug('scheduled graph', graphStatus);
 
-  // Track each bug as having an active taskgraph, so we can rebuild the integration branch.
-  if (runtime.bugStore.activeBugs.indexOf(bugId) === -1) {
-    runtime.bugStore.activeBugs.push(bugId);
-  }
+  // Track each bug as an active integration. This lets us rebuild the integration branch when needed
+  // and also notify successfully integrated coalesced bugs of landing.
   runtime.bugStore.activeTaskGraphIds[id] = bugId;
+  runtime.bugStore.activeIntegrations.push({
+    taskgraphId: id,
+    bugId: bugId,
+    params: params
+  });
 };

--- a/test/fast_forward_coalesce_success_test.js
+++ b/test/fast_forward_coalesce_success_test.js
@@ -1,0 +1,95 @@
+var assert = require('assert');
+var co = require('co');
+var helper = require('./helper');
+var fs = require('fs');
+var jsTemplate = require('json-templater/object');
+var slugid = require('slugid');
+
+var commitContent = require('./support/commit_content');
+var createBug = require('./support/create_bug');
+var createPullRequest = require('./support/create_pull_request');
+var branchFromMaster = require('./support/branch_from_master');
+var getBugComments = require('./support/get_bug_comments');
+var getCommits = require('./support/get_commits');
+var reviewAttachment = require('./support/review_attachment');
+var setCheckinNeeded = require('./support/set_checkin_needed');
+var waitForAttachments = require('./support/wait_for_attachments');
+var waitForLandingComment = require('./support/wait_for_landing_comment');
+var waitForCheckinNeededRemoved = require('./support/wait_for_checkin_needed_removed');
+var waitForPullState = require('./support/wait_for_pull_state');
+
+suite('fast forward coalesce > ', function() {
+  var runtime;
+
+  suiteSetup(co(function * () {
+    runtime = yield require('./support/runtime')()
+    return yield helper.setup(runtime);
+  }));
+
+  suiteTeardown(co(function * () {
+    return yield helper.teardown(runtime);
+  }));
+
+  test('two pull requests are coalesced into a success state', co(function * () {
+    // Make a slow taskgraph which might not even finish before the test is done.
+    // The result of this one does't really matter, we just care that the success
+    // case and commenting is done in the case of a coalesce.
+    var taskgraphFirstSlow = fs.readFileSync(__dirname + '/fixtures/tc_success/taskgraph.json', 'utf-8');
+    taskgraphFirstSlow = jsTemplate(taskgraphFirstSlow, {
+      taskId: slugid.v4()
+    });
+    taskgraphFirstSlow = JSON.parse(taskgraphFirstSlow);
+    taskgraphFirstSlow.tasks[0].task.payload.command[2] = "sleep 5m && echo \"Hello World\";"
+    taskgraphFirstSlow = JSON.stringify(taskgraphFirstSlow);
+
+    var taskgraphFastSuccess = fs.readFileSync(__dirname + '/fixtures/tc_success/taskgraph.json', 'utf-8');
+    taskgraphFastSuccess = jsTemplate(taskgraphFastSuccess, {
+      taskId: slugid.v4()
+    });
+
+    yield commitContent(runtime, 'master', 'taskgraph.json', taskgraphFirstSlow);
+    var bug1 = yield createBug(runtime);
+    var bug2 = yield createBug(runtime);
+
+    // Submit the "slow" pull request.
+    yield branchFromMaster(runtime, 'branch1');
+    yield commitContent(runtime, 'branch1', 'foo.txt', 'bar');
+    var pullSlow = yield createPullRequest(runtime, 'branch1', 'master', 'Bug ' + bug1.id + ' - slow taskgraph - success to be coalesced');
+    var attachments1 = yield waitForAttachments(runtime, bug1.id);
+    yield reviewAttachment(runtime, attachments1[0]);
+    yield setCheckinNeeded(runtime, bug1.id);
+
+    // Wait until the "slow" pull request is in a pending state.
+    yield waitForPullState(runtime, 'autolander', 'autolander-test', 'branch1', 'pending');
+
+    // Submit the "fast" pull request, which should pass first.
+    yield branchFromMaster(runtime, 'branch2');
+    yield commitContent(runtime, 'branch2', 'taskgraph.json', taskgraphFastSuccess);
+    yield createPullRequest(runtime, 'branch2', 'master', 'Bug ' + bug2.id + ' - Autolander success taskgraph');
+
+    var attachments2 = yield waitForAttachments(runtime, bug2.id);
+    yield reviewAttachment(runtime, attachments2[0]);
+    yield setCheckinNeeded(runtime, bug2.id);
+
+    // The second bug should be checked-in immediately (after the success taskgraph).
+    yield waitForCheckinNeededRemoved(runtime, bug2.id);
+    yield waitForLandingComment(runtime, bug2.id);
+
+    // We should also immediately have a landing comment in bug1.
+    // Note: we can't use waitFor here, otherwise we will wait until the "slow" taskgraph finishes.
+    var comments = yield getBugComments(runtime, bug1.id);
+    var found = false;
+    for (var i = 0; i < comments.length; i++) {
+      if (comments[i].text.indexOf('Pull request has landed in master') !== -1) {
+        found = true;
+      }
+    }
+    assert.equal(found, true);
+
+    // The master branch should have five commits:
+    // One original commit, and two from each branch including the merges to the integration branch.
+    var commits = yield getCommits(runtime, 'autolander', 'autolander-test');
+    assert.equal(commits.length, 5);
+    assert.equal(commits[0].commit.message, 'Merge branch2 into integration-master');
+  }));
+});

--- a/test/fast_forward_conflict_rebuild_test.js
+++ b/test/fast_forward_conflict_rebuild_test.js
@@ -1,0 +1,71 @@
+var assert = require('assert');
+var co = require('co');
+var helper = require('./helper');
+var fs = require('fs');
+var jsTemplate = require('json-templater/object');
+var slugid = require('slugid');
+
+var commitContent = require('./support/commit_content');
+var createBug = require('./support/create_bug');
+var createPullRequest = require('./support/create_pull_request');
+var branchFromMaster = require('./support/branch_from_master');
+var getCommits = require('./support/get_commits');
+var reviewAttachment = require('./support/review_attachment');
+var setCheckinNeeded = require('./support/set_checkin_needed');
+var waitForAttachments = require('./support/wait_for_attachments');
+var waitForCheckinNeededRemoved = require('./support/wait_for_checkin_needed_removed');
+var waitForLandingComment = require('./support/wait_for_landing_comment');
+var waitForPullState = require('./support/wait_for_pull_state');
+var waitForResolvedFixed = require('./support/wait_for_resolved_fixed');
+
+suite('fast forward conflict > ', function() {
+  var runtime;
+
+  suiteSetup(co(function * () {
+    runtime = yield require('./support/runtime')()
+    return yield helper.setup(runtime);
+  }));
+
+  suiteTeardown(co(function * () {
+    return yield helper.teardown(runtime);
+  }));
+
+  test('retries after fast-forward conflict', co(function * () {
+    // Make a slow taskgraph which might not even finish before the test is done.
+    // The result of this one does't really matter, we just care that the success
+    // case and commenting is done in the case of a coalesce.
+    var taskgraph = fs.readFileSync(__dirname + '/fixtures/tc_success/taskgraph.json', 'utf-8');
+    taskgraph = jsTemplate(taskgraph, {
+      taskId: slugid.v4()
+    });
+
+    yield commitContent(runtime, 'master', 'taskgraph.json', taskgraph);
+    var bug1 = yield createBug(runtime);
+
+    yield branchFromMaster(runtime, 'branch1');
+    yield commitContent(runtime, 'branch1', 'foo.txt', 'foo');
+    var pullSlow = yield createPullRequest(runtime, 'branch1', 'master', 'Bug ' + bug1.id + ' - expecting a conflict on fast-forward');
+    var attachments1 = yield waitForAttachments(runtime, bug1.id);
+    yield reviewAttachment(runtime, attachments1[0]);
+    yield setCheckinNeeded(runtime, bug1.id);
+
+    // Wait until the pull request is in a pending state.
+    // This way we know that we've already branched to the integration-master branch.
+    // This is important so we know we don't have our later commit from master which we use to intentionally ruin the fast-forward.
+    yield waitForPullState(runtime, 'autolander', 'autolander-test', 'branch1', 'pending');
+
+    // Commit some content to master so it's no longer a fast-forward.
+    yield commitContent(runtime, 'master', 'bar.txt', 'bar');
+
+    // Make sure the retry landing looks good.
+    yield waitForLandingComment(runtime, bug1.id);
+    yield waitForCheckinNeededRemoved(runtime, bug1.id);
+    yield waitForResolvedFixed(runtime, bug1.id);
+
+    // The master branch should have four commits:
+    // Two commits in master, and two from the branch including the merge to the integration branch.
+    var commits = yield getCommits(runtime, 'autolander', 'autolander-test');
+    assert.equal(commits.length, 4);
+    assert.equal(commits[0].commit.message, 'Merge branch1 into integration-master');
+  }));
+});

--- a/test/support/get_commits.js
+++ b/test/support/get_commits.js
@@ -1,0 +1,17 @@
+var thunkify = require('thunkify');
+
+/**
+ * Gets commits for a branch.
+ * @param {Object} runtime
+ * @param {String} user
+ * @param {String} repo
+ */
+module.exports = function * (runtime, user, repo) {
+  yield runtime.sleep();
+  var getCommits = thunkify(runtime.githubApi.repos.getCommits.bind(runtime.githubApi.repos));
+  return yield getCommits({
+    user: user,
+    repo: repo,
+    token: runtime.config.githubConfig.token
+  });
+};

--- a/test/support/wait_for_pull_state.js
+++ b/test/support/wait_for_pull_state.js
@@ -1,0 +1,25 @@
+var getStatusesFromBranchTip = require('./get_statuses_from_branch_tip');
+var Promise = require('promise');
+
+var WAIT_INTERVAL = 5000;
+var MAX_TRIES = 20;
+
+/**
+ * Waits for a pull request to have a certain status.
+ * @param {Object} runtime
+ * @param {String} head
+ * @param {String} base
+ * @param {String} branch
+ * @param {String} state
+ */
+module.exports = function * (runtime, user, repo, branch, state) {
+  var tries = 0;
+  while (tries++ < MAX_TRIES) {
+    var statuses = yield getStatusesFromBranchTip(runtime, user, repo, branch);
+    if (statuses.length >= 1 && statuses[0].state === state){
+      return statuses;
+    }
+    yield runtime.sleep(WAIT_INTERVAL);
+  }
+  throw new Error('Cound not find pull request comment.');
+};

--- a/test/taskgraph_failure_test.js
+++ b/test/taskgraph_failure_test.js
@@ -43,6 +43,12 @@ suite('taskgraph failure > ', function() {
       taskId: slugid.v4()
     });
 
+    // Give the failure case a bit more time to complete first by adding an additional sleep.
+    // In an ideal world we would control the taskgraph state explicitly and tell this when to pass.
+    taskgraphSuccess = JSON.parse(taskgraphSuccess);
+    taskgraphSuccess.tasks[0].task.payload.command[2] = "sleep 50s && echo \"Hello World\";"
+    taskgraphSuccess = JSON.stringify(taskgraphSuccess);
+
     yield commitContent(runtime, 'master', 'taskgraph.json', taskgraphFailure);
     var bug1 = yield createBug(runtime);
     var bug2 = yield createBug(runtime);

--- a/test/taskgraph_success_test.js
+++ b/test/taskgraph_success_test.js
@@ -9,6 +9,7 @@ var commitContent = require('./support/commit_content');
 var commitToBranch = require('./support/commit_to_branch');
 var createBug = require('./support/create_bug');
 var createPullRequest = require('./support/create_pull_request');
+var getCommits = require('./support/get_commits');
 var getReference = require('./support/get_reference');
 var getStatusesFromBranchTip = require('./support/get_statuses_from_branch_tip');
 var branchFromMaster = require('./support/branch_from_master');
@@ -66,5 +67,12 @@ suite('taskgraph success > ', function() {
     // The integration branch should go away after a successful integration.
     var integrationBranch = yield getReference(runtime, 'autolander', 'autolander-test', 'integration-master');
     assert.equal(integrationBranch, null);
+
+    // The master branch should have three commits:
+    // One original commit, one from the branch, and one branch -> integration branch merge.
+    // Eventually we would like to fast-forward the integration branch, so this would only be 2 commits.
+    var commits = yield getCommits(runtime, 'autolander', 'autolander-test');
+    assert.equal(commits.length, 3);
+    assert.equal(commits[0].commit.message, 'Merge branch1 into integration-master');
   }));
 });


### PR DESCRIPTION
This adds fast-forward support. Whenever a taskgraph passes we fast-forward the target branch to the passing commit. This adds support for a few things:
- Adds logic for notifying all bugs which were coalesced into a successful landing.
- Adds retry logic in the case we can't fast-forward. In this case we re-create the integration branch, and retry all pending jobs on top of the integration branch.

https://bugzilla.mozilla.org/show_bug.cgi?id=1093759
