### PR TITLE
Bug 1109162 - Do not validate commit names for non-landable patches +autoland

### DIFF
--- a/lib/bugzilla.js
+++ b/lib/bugzilla.js
@@ -20,12 +20,6 @@ exports.canLand = function * (runtime, bug, attachment, pull) {
     return false;
   }
 
-  // Validate that the pull request commits all have bug numbers. Return if they don't.
-  var hasBugNumbers = yield validator.pullRequestCommitsHasBug(runtime, pull, bug);
-  if (!hasBugNumbers) {
-    return;
-  }
-
   var getSuggestedReviewers = thunkify(runtime.bugzillaApi.getSuggestedReviewers.bind(runtime.bugzillaApi));
   var suggestedReviewers = yield getSuggestedReviewers(bug.id);
   var suggestedReviewersEmails = {};
@@ -50,6 +44,14 @@ exports.canLand = function * (runtime, bug, attachment, pull) {
     }
   }
   debug('has R+, and is from suggested reviewer?', hasReview, hasSuggestedReview);
+
+  // Validate that the pull request commits all have bug numbers. Return if they don't.
+  if (hasReview) {
+    var hasBugNumbers = yield validator.pullRequestCommitsHasBug(runtime, pull, bug);
+    if (!hasBugNumbers) {
+      return false;
+    }
+  }
 
   if (hasReview && hasSuggestedReview) {
     // This can return true if the patch has one R- and one R+. We generally accept this case as

--- a/test/validate_not_applied_unlandable_pull_test.js
+++ b/test/validate_not_applied_unlandable_pull_test.js
@@ -1,0 +1,60 @@
+var assert = require('assert');
+var co = require('co');
+var fs = require('fs');
+var helper = require('./helper');
+var jsTemplate = require('json-templater/object');
+var slugid = require('slugid');
+
+var branchFromRef = require('./support/branch_from_ref');
+var commitContent = require('./support/commit_content');
+var createBug = require('./support/create_bug');
+var createPullRequest = require('./support/create_pull_request');
+var getPullComments = require('./support/get_pull_comments');
+var reviewAttachment = require('./support/review_attachment');
+var setCheckinNeeded = require('./support/set_checkin_needed');
+var waitForAttachments = require('./support/wait_for_attachments');
+var waitForLandingComment = require('./support/wait_for_landing_comment');
+var waitForResolvedFixed = require('./support/wait_for_resolved_fixed');
+var waitForCheckinNeededRemoved = require('./support/wait_for_checkin_needed_removed');
+
+suite('commit message validation does not appear > ', function() {
+  var runtime;
+
+  suiteSetup(co(function * () {
+    runtime = yield require('./support/runtime')()
+    return yield helper.setup(runtime);
+  }));
+
+  suiteTeardown(co(function * () {
+    return yield helper.teardown(runtime);
+  }));
+
+  test('when bug has two pull requests and only one can land', co(function * () {
+    var bug = yield createBug(runtime);
+
+    yield commitContent(runtime, 'master', 'foo.txt', 'foo', 'Bug ' + bug.id + ' - add foo.txt');
+
+    yield branchFromRef(runtime, 'branch1');
+    yield commitContent(runtime, 'branch1', 'baz.txt', 'baz', 'some invalid commit message');
+    var pull1 = yield createPullRequest(runtime, 'branch1', 'master', 'Bug ' + bug.id + ' - non-landable, fails validation');
+
+    yield branchFromRef(runtime, 'branch2');
+    yield commitContent(runtime, 'branch2', 'foo.txt', 'bar', 'Bug ' + bug.id + ' - update foo.txt');
+    var pull2 = yield createPullRequest(runtime, 'branch2', 'master', 'Bug ' + bug.id + ' - landable, passes validation');
+
+    var attachments = yield waitForAttachments(runtime, bug.id, 2);
+    yield reviewAttachment(runtime, attachments[1]);
+    yield setCheckinNeeded(runtime, bug.id);
+
+    // The empty tc case should pass immediately, and we should land and comment in the bug.
+    yield waitForLandingComment(runtime, bug.id);
+    yield waitForCheckinNeededRemoved(runtime, bug.id);
+    yield waitForResolvedFixed(runtime, bug.id);
+
+    // Sleep for 10 seconds or so and make sure that the pull request which should not be landed
+    // does not receive any validation comments.
+    yield runtime.sleep(10000);
+    var comments = yield getPullComments(runtime, 'autolander', 'autolander-test', pull1.number);
+    assert.equal(comments.length, 0);
+  }));
+});


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1109162

Tests passing:
![screen shot 2014-12-09 at 6 25 29 pm](https://cloud.githubusercontent.com/assets/122602/5369995/cebb4fe0-7fd0-11e4-9c52-cb33be1c038b.png)
