### PR TITLE
use new treeherder route

### DIFF
--- a/config/development.js.tpl
+++ b/config/development.js.tpl
@@ -41,6 +41,7 @@ module.exports = {
   },
   treeherderConfig: {
     name: 'gaia-try',
+    route: 'tc-treeherder-staging',
     baseUrl: ENV('TREEHERDER_URL') || 'https://treeherder.mozilla.org/',
     consumerKey: ENV('TREEHERDER_KEY'),
     consumerSecret: ENV('TREEHERDER_SECRET')

--- a/config/production.js
+++ b/config/production.js
@@ -41,6 +41,7 @@ module.exports = {
   },
   treeherderConfig: {
     name: 'gaia-try',
+    route: 'tc-treeherder',
     baseUrl: ENV('TREEHERDER_URL') || 'https://treeherder.mozilla.org/',
     consumerKey: ENV('TREEHERDER_KEY'),
     consumerSecret: ENV('TREEHERDER_SECRET')

--- a/lib/taskgraph.js
+++ b/lib/taskgraph.js
@@ -19,8 +19,6 @@ const TASKGRAPH_PATHS = [
   'taskgraph.json'
 ];
 
-
-const TREEHERDER_ROUTE = 'tc-treeherder';
 const TASKCLUSTER_ROUTE = 'gaia-autolander';
 
 var formatCommitsForResultSet = function(project, commits) {
@@ -192,7 +190,7 @@ exports.create = function * (runtime, bugId, pull, integrationMerge) {
     treeherderRevision: integrationMerge.sha
   };
 
-  var treeherderRoute = TREEHERDER_ROUTE + '.' +
+  var treeherderRoute = runtime.config.treeherderConfig.route + '.' +
     PROJECT_NAME + '.' +
     integrationMerge.sha;
 

--- a/lib/taskgraph.js
+++ b/lib/taskgraph.js
@@ -20,7 +20,7 @@ const TASKGRAPH_PATHS = [
 ];
 
 
-const TREEHERDER_ROUTE = 'treeherder';
+const TREEHERDER_ROUTE = 'tc-treeherder';
 const TASKCLUSTER_ROUTE = 'gaia-autolander';
 
 var formatCommitsForResultSet = function(project, commits) {


### PR DESCRIPTION
This is production TH + the new push logic which handles platform/machine types as well as new throttling model treeherder uses