### PR TITLE
Bug 1194767 - use slugid.nice() instead of slugid.v4()

### DIFF
--- a/lib/taskgraph.js
+++ b/lib/taskgraph.js
@@ -267,11 +267,11 @@ exports.create = function * (runtime, bugId, pull, integrationMerge) {
   graph = GraphFactory.create(jsTemplate(graph, params));
 
   graph.tasks = graph.tasks.map(function(task) {
-    task.taskId = slugid.v4();
+    task.taskId = slugid.nice();
     return task;
   });
 
-  var id = slugid.v4();
+  var id = slugid.nice();
   debug('create graph', {
     id: id,
     graph: JSON.stringify(graph)

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "mozilla-treeherder": "^0.4.2",
     "ngrok": "^0.1.98",
     "promise": "~4.0.0",
-    "slugid": "^1.0.3",
+    "slugid": "^1.1.0",
     "taskcluster-client": "^0.17.7",
     "taskcluster-task-factory": "^0.6.4",
     "thunkify": "^2.1.2"

--- a/test/active_integration_store_restart_server_test.js
+++ b/test/active_integration_store_restart_server_test.js
@@ -38,7 +38,7 @@ suite('active integration store > ', function() {
   test('persists active taskgraphs after a server restart', co(function * () {
     var taskgraph = fs.readFileSync(__dirname + '/fixtures/tc_success/taskgraph.json', 'utf-8');
     taskgraph = jsTemplate(taskgraph, {
-      taskId: slugid.v4()
+      taskId: slugid.nice()
     });
 
     // Give the taskgraph a bit extra time to complete so we can shutdown the server before it starts.

--- a/test/fast_forward_coalesce_success_test.js
+++ b/test/fast_forward_coalesce_success_test.js
@@ -38,7 +38,7 @@ suite('fast forward coalesce > ', function() {
     // case and commenting is done in the case of a coalesce.
     var taskgraphFirstSlow = fs.readFileSync(__dirname + '/fixtures/tc_success/taskgraph.json', 'utf-8');
     taskgraphFirstSlow = jsTemplate(taskgraphFirstSlow, {
-      taskId: slugid.v4()
+      taskId: slugid.nice()
     });
     taskgraphFirstSlow = JSON.parse(taskgraphFirstSlow);
     taskgraphFirstSlow.tasks[0].task.payload.command[2] = "sleep 5m && echo \"Hello World\";"
@@ -46,7 +46,7 @@ suite('fast forward coalesce > ', function() {
 
     var taskgraphFastSuccess = fs.readFileSync(__dirname + '/fixtures/tc_success/taskgraph.json', 'utf-8');
     taskgraphFastSuccess = jsTemplate(taskgraphFastSuccess, {
-      taskId: slugid.v4()
+      taskId: slugid.nice()
     });
 
     yield commitContent(runtime, 'master', 'taskgraph.json', taskgraphFirstSlow);
@@ -74,7 +74,7 @@ suite('fast forward coalesce > ', function() {
     yield branchFromRef(runtime, 'branch3', 'branch2');
     var taskgraphFailure = fs.readFileSync(__dirname + '/fixtures/tc_failure/taskgraph.json', 'utf-8');
     taskgraphFailure = jsTemplate(taskgraphFailure, {
-      taskId: slugid.v4()
+      taskId: slugid.nice()
     });
     yield commitContent(runtime, 'branch3', 'taskgraph.json', taskgraphFailure, 'Bug ' + bug3.id + ' - add failure taskgraph');
     yield createPullRequest(runtime, 'branch3', 'master', 'Bug ' + bug3.id + ' - Autolander failure, should not land');

--- a/test/fast_forward_conflict_rebuild_test.js
+++ b/test/fast_forward_conflict_rebuild_test.js
@@ -34,7 +34,7 @@ suite('fast forward conflict > ', function() {
   test('retries after fast-forward conflict', co(function * () {
     var taskgraph = fs.readFileSync(__dirname + '/fixtures/tc_success/taskgraph.json', 'utf-8');
     taskgraph = jsTemplate(taskgraph, {
-      taskId: slugid.v4()
+      taskId: slugid.nice()
     });
 
     yield commitContent(runtime, 'master', 'taskgraph.json', taskgraph);

--- a/test/invalid_taskgraph_test.js
+++ b/test/invalid_taskgraph_test.js
@@ -32,7 +32,7 @@ suite('invalid taskgraph > ', function() {
   test('comments on PR and removes autoland', co(function * () {
     var taskgraph = fs.readFileSync(__dirname + '/fixtures/tc_success/taskgraph.json', 'utf-8');
     taskgraph = jsTemplate(taskgraph, {
-      taskId: slugid.v4()
+      taskId: slugid.nice()
     }) + ' - Make this taskgraph invalid.';
 
     yield commitContent(runtime, 'master', 'taskgraph.json', taskgraph);

--- a/test/multiple_pull_requests_on_bug_test.js
+++ b/test/multiple_pull_requests_on_bug_test.js
@@ -32,7 +32,7 @@ suite('multiple pull requests > ', function() {
   test('with multiple autoland requests', co(function * () {
     var taskgraph = fs.readFileSync(__dirname + '/fixtures/tc_success/taskgraph.json', 'utf-8');
     taskgraph = jsTemplate(taskgraph, {
-      taskId: slugid.v4()
+      taskId: slugid.nice()
     });
 
     yield commitContent(runtime, 'master', 'taskgraph.json', taskgraph);

--- a/test/processes_only_once_test.js
+++ b/test/processes_only_once_test.js
@@ -37,7 +37,7 @@ suite('processing duplicate bug notifications > ', function() {
     // Make a slow taskgraph, which will eventually pass.
     var taskgraphFirstSlow = fs.readFileSync(__dirname + '/fixtures/tc_success/taskgraph.json', 'utf-8');
     taskgraphFirstSlow = jsTemplate(taskgraphFirstSlow, {
-      taskId: slugid.v4()
+      taskId: slugid.nice()
     });
     taskgraphFirstSlow = JSON.parse(taskgraphFirstSlow);
     taskgraphFirstSlow.tasks[0].task.payload.command[2] = "sleep 10s && echo \"Hello World\";"

--- a/test/pull_request_multiple_commits_test.js
+++ b/test/pull_request_multiple_commits_test.js
@@ -33,7 +33,7 @@ suite('multiple commits in a pull request > ', function() {
   test('comments with the merge commit', co(function * () {
     var taskgraph = fs.readFileSync(__dirname + '/fixtures/tc_success/taskgraph.json', 'utf-8');
     taskgraph = jsTemplate(taskgraph, {
-      taskId: slugid.v4()
+      taskId: slugid.nice()
     });
 
     yield commitContent(runtime, 'master', 'temp', 'foo');

--- a/test/taskgraph_failure_test.js
+++ b/test/taskgraph_failure_test.js
@@ -35,12 +35,12 @@ suite('taskgraph failure > ', function() {
   test('successful patch lands after a failure', co(function * () {
     var taskgraphFailure = fs.readFileSync(__dirname + '/fixtures/tc_failure/taskgraph.json', 'utf-8');
     taskgraphFailure = jsTemplate(taskgraphFailure, {
-      taskId: slugid.v4()
+      taskId: slugid.nice()
     });
 
     var taskgraphSuccess = fs.readFileSync(__dirname + '/fixtures/tc_success/taskgraph.json', 'utf-8');
     taskgraphSuccess = jsTemplate(taskgraphSuccess, {
-      taskId: slugid.v4()
+      taskId: slugid.nice()
     });
 
     // Give the failure case a bit more time to complete first by adding an additional sleep.

--- a/test/taskgraph_fallback_autolander_json_test.js
+++ b/test/taskgraph_fallback_autolander_json_test.js
@@ -31,12 +31,12 @@ suite('taskgraph selection > ', function() {
   test('uses autolander.json if it exists', co(function * () {
     var taskgraphFailure = fs.readFileSync(__dirname + '/fixtures/tc_failure/taskgraph.json', 'utf-8');
     taskgraphFailure = jsTemplate(taskgraphFailure, {
-      taskId: slugid.v4()
+      taskId: slugid.nice()
     });
 
     var taskgraphSuccess = fs.readFileSync(__dirname + '/fixtures/tc_success/autolander.json', 'utf-8');
     taskgraphSuccess = jsTemplate(taskgraphSuccess, {
-      taskId: slugid.v4()
+      taskId: slugid.nice()
     });
 
     yield commitContent(runtime, 'master', 'taskgraph.json', taskgraphFailure);

--- a/test/taskgraph_success_test.js
+++ b/test/taskgraph_success_test.js
@@ -37,7 +37,7 @@ suite('taskgraph success > ', function() {
   test('patch is autolanded', co(function * () {
     var taskgraph = fs.readFileSync(__dirname + '/fixtures/tc_success/taskgraph.json', 'utf-8');
     taskgraph = jsTemplate(taskgraph, {
-      taskId: slugid.v4()
+      taskId: slugid.nice()
     });
 
     yield commitContent(runtime, 'master', 'taskgraph.json', taskgraph);

--- a/test/treeherder_timeout_test.js
+++ b/test/treeherder_timeout_test.js
@@ -36,7 +36,7 @@ suite('treeherder timeout > ', function() {
   test('patch is autolanded even if TH times out', co(function * () {
     var taskgraph = fs.readFileSync(__dirname + '/fixtures/tc_success/taskgraph.json', 'utf-8');
     taskgraph = jsTemplate(taskgraph, {
-      taskId: slugid.v4()
+      taskId: slugid.nice()
     });
 
     yield commitContent(runtime, 'master', 'taskgraph.json', taskgraph);

--- a/test/validate_commit_has_bug_number_test.js
+++ b/test/validate_commit_has_bug_number_test.js
@@ -30,7 +30,7 @@ suite('validates commit message title > ', function() {
   test('when missing a bug number', co(function * () {
     var taskgraph = fs.readFileSync(__dirname + '/fixtures/tc_success/taskgraph.json', 'utf-8');
     taskgraph = jsTemplate(taskgraph, {
-      taskId: slugid.v4()
+      taskId: slugid.nice()
     });
     yield commitContent(runtime, 'master', 'taskgraph.json', taskgraph, 'Initial commit.');
 


### PR DESCRIPTION
See bug for context, essentially this just avoids that slugids start with a '-' char - see e.g. https://treeherder.mozilla.org/#/jobs?repo=gaia&revision=47c5f2a1abc1c50e397ded8b4b25e5e343bebcf5 that caused @wilsonpage some problems earlier today.

Ideally docker worker should still be able to handle such slugids, since we only recommend that "nice" slugids are used, and don't mandate it. I'll raise a separate bug about that, but in the meantime we might as well use safe ones, which further protects any downstream tools.