### PR TITLE
Bug 1233745 - Update to newer nodejs to fix Heroku build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: requried
+dist: trusty
+language: node_js
+node_js:
+  - "4.2"
+install:
+  - npm install
+before_script:
+  - cp config/development.js.tpl config/development.js
+script:
+  - echo "skipping test run until environment variables are set up"
+  #- npm test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Autolander
 ==========
 [![Build Status](https://travis-ci.org/mozilla/autolander.svg?branch=master)](https://travis-ci.org/mozilla/autolander)
+[![Dependency Status](https://david-dm.org/mozilla/autolander.svg)](https://david-dm.org/mozilla/autolander)
+[![devDependency Status](https://david-dm.org/mozilla/autolander/dev-status.svg)](https://david-dm.org/mozilla/autolander#info=devDependencies)
 
 ## Description:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Autolander
+Autolander
+==========
+[![Build Status](https://travis-ci.org/mozilla/autolander.svg?branch=master)](https://travis-ci.org/mozilla/autolander)
+
+## Description:
 
 Autolander is a tool which manages continuous integration workflows between Bugzilla and Github. Autolander has several features including:
 

--- a/package.json
+++ b/package.json
@@ -1,19 +1,18 @@
 {
   "name": "autolander",
   "version": "0.0.0",
-  "description": "autolander ================",
-  "main": "index.js",
+  "description": "A tool that manages CI workflows between Bugzilla and Github",
   "scripts": {
     "test": "./test/runall.sh"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/KevinGrandon/autolander.git"
+    "url": "git://github.com/mozilla/autolander.git"
   },
   "author": "Kevin Grandon <kevingrandon@yahoo.com>",
   "license": "MPL",
   "bugs": {
-    "url": "https://github.com/KevinGrandon/autolander/issues"
+    "url": "https://github.com/mozilla/autolander/issues"
   },
   "engines" : {
     "node" : "0.11.14"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/mozilla/autolander/issues"
   },
   "engines" : {
-    "node" : "0.11.14"
+    "node" : "4.2"
   },
   "devDependencies": {
     "mocha": "~2.0.1",


### PR DESCRIPTION
Also adds a WIP Travis config that confirms `npm install` now succeeds. It doesn't yet run `npm test` since the tests require actual credentials, which we can either enter securely via Travis settings, or else the tests could be rewritten to be entirely mocked.

Once this lands, someone with admin access to the autolander repo will need to enable the Travis hook via:
https://travis-ci.org/profile

Finally, I've also added some david-dm.org badges to make it easier to see which dependencies are out of date.

See individual commit messages for more detail.