### PR TITLE
Correct the Treeherder jobs URL

### DIFF
--- a/routes/taskgraph_update.js
+++ b/routes/taskgraph_update.js
@@ -58,7 +58,7 @@ module.exports = function(runtime) {
       return;
     }
 
-    params.treeherderUrl = runtime.config.treeherderConfig.baseUrl + 'ui/#/jobs?repo=gaia-try&revision=' + revisionInfo[0].revision;
+    params.treeherderUrl = runtime.config.treeherderConfig.baseUrl + '#/jobs?repo=gaia-try&revision=' + revisionInfo[0].revision;
 
     switch (detail.payload.status.state) {
       case 'running':


### PR DESCRIPTION
The 'ui/' was removed in bug 1063411 and the redirects were removed some time after, so the old style URLs now 404.