### PR TITLE
Bug 1237261 - Only process certain pull request events

### DIFF
--- a/lib/web.js
+++ b/lib/web.js
@@ -46,6 +46,8 @@ module.exports = function * createApp(config) {
     if (!body) {
       return this.throw(400, 'Must contain a body');
     }
+    // The POST body is of form:
+    // https://developer.github.com/v3/activity/events/types/#pullrequestevent
     var pull = body.pull_request;
 
     // Do not send the request to a worker if this repo requires a key in the name
@@ -72,7 +74,8 @@ module.exports = function * createApp(config) {
       meta: {
         owner: repoParts[0],
         repo: repoParts[1],
-        number: pull.number
+        number: pull.number,
+        action: body.action
       }
     })));
     this.status = 200;


### PR DESCRIPTION
When autolander receives a pull request event from GitHub, it may do one of two things:
1) Comment on the PR if a bug number was not found
2) If a bug number was found, create an attachment on that bug if it does not already exist.

As such, only events that either create a new PR, or update the PR's title or commit messages are relevant.

In addition, this helps avoid race conditions in cases where multiple events are generated at the same time (for example when a PR has an assignee set at the time of creation, both "opened" and "assigned" events are sent).