### PR TITLE
Bug 1238884 - Perform post-merge bug updates as a single action

### DIFF
--- a/lib/bugzilla.js
+++ b/lib/bugzilla.js
@@ -223,21 +223,6 @@ exports.removeCheckinNeeded = function * (runtime, bugId) {
 };
 
 /**
- * Comments on bugzilla about the merge.
- * @param {Object} runtime
- * @param {Integer} bugId
- * @param {String} branchName
- * @param {String} commitUrl
- */
-exports.addLandingComment = function * (runtime, bugId, branchName, commitUrl) {
-  var comment = {
-    comment: 'Pull request has landed in ' + branchName + ': ' + commitUrl
-  };
-  var addComment = thunkify(runtime.bugzillaApi.addComment.bind(runtime.bugzillaApi));
-  yield addComment(bugId, comment);
-};
-
-/**
  * Comments on bugzilla when CI failes.
  * @param {Object} runtime
  * @param {Integer} bugId
@@ -253,17 +238,26 @@ exports.addCiFailedComment = function * (runtime, bugId, comment) {
 };
 
 /**
- * Mark a bug as resolved fixed.
+ * Adds a bug comment about the merge, removes the 'autoland' keyword
+ * and marks the bug as RESOLVED FIXED.
  * @param {Object} runtime
  * @param {Integer} bugId
+ * @param {String} branchName
+ * @param {String} commitUrl
  */
-exports.resolveFix = function * (runtime, bugId) {
+exports.updateBugAfterMerge = function * (runtime, bugId, branchName, commitUrl) {
   var updateBug = thunkify(runtime.bugzillaApi.updateBug.bind(runtime.bugzillaApi));
   var updatedBugResp = yield updateBug(bugId, {
+    comment: {
+      body: 'Pull request has landed in ' + branchName + ': ' + commitUrl
+    },
+    keywords: {
+      'remove': ['autoland']
+    },
     status: 'RESOLVED',
     resolution: 'FIXED'
   });
-  debug('updated bug status', updatedBugResp);
+  debug('Updated bug.', updatedBugResp);
 };
 
 /**
@@ -291,9 +285,7 @@ exports.mergePullRequest = function * (runtime, bugId, pull, baseBranch) {
   }
 
   var commitUrl = 'https://github.com/' + pull.base.repo.full_name + '/commit/' + merge.sha;
-  yield exports.addLandingComment(runtime, bugId, baseBranch, commitUrl);
-  yield exports.removeCheckinNeeded(runtime, bugId);
-  yield exports.resolveFix(runtime, bugId);
+  yield exports.updateBugAfterMerge(runtime, bugId, baseBranch, commitUrl);
   yield removeBranch(runtime, repoParts[0], repoParts[1], 'integration-' + baseBranch);
 
   return merge;

--- a/routes/taskgraph_update.js
+++ b/routes/taskgraph_update.js
@@ -198,9 +198,7 @@ var notifyCoalescedBugs = function * (runtime, params) {
 
     try {
       var commitUrl = 'https://github.com/' + job.githubBaseUser + '/' + job.githubBaseRepo + '/commit/' + job.githubPullMergeSha;
-      yield bugzilla.addLandingComment(runtime, job.bugId, job.githubBaseBranch, commitUrl);
-      yield bugzilla.removeCheckinNeeded(runtime, job.bugId);
-      yield bugzilla.resolveFix(runtime, job.bugId);
+      yield bugzilla.updateBugAfterMerge(runtime, job.bugId, job.githubBaseBranch, commitUrl);
     } catch (e) {
       debug('could not add landing commit', job, e);
     }


### PR DESCRIPTION
Previously the comment addition, keyword removal and bug closure were performed as three separate actions, resulting in unnecessary email spam as well as making the bug thread harder to read.

The previous `addLandingComment`, `removeCheckinNeeded` and `resolveFix` steps have been combined into a new `updateBugAfterMerge`. The original `removeCheckinNeeded` has to be left as-is, since unlike the other functions, is used elsewhere on its own (eg in error cases).

The comment addition is now performed via the bug endpoint, rather than the comment endpoint. The `comment` object is described here:
http://bugzilla.readthedocs.io/en/latest/api/core/v1/bug.html#update-bug