### PR TITLE
Bug 1235619 - Only warn about missing bug numbers on PR creation

### DIFF
--- a/lib/github/validator.js
+++ b/lib/github/validator.js
@@ -12,11 +12,13 @@ const BUG_PATTERN = /^.*Bug\s{1}([0-9]{5,})\s{1}-{1}\s{1}.*/;
  * @param {Object} pull
  * @return {Number}
  */
-exports.pullRequestHasBug = function * (runtime, pull) {
+exports.pullRequestHasBug = function * (runtime, pull, addComment) {
   var bugId = pull.title.match(BUG_PATTERN);
   if (!bugId || !bugId[1]) {
-    var repoParts = pull.base.repo.full_name.split('/');
-    yield github.addComment(runtime, repoParts[0], repoParts[1], pull.number, github.COMMENTS.NO_BUG_FOUND);
+    if (addComment) {
+      var repoParts = pull.base.repo.full_name.split('/');
+      yield github.addComment(runtime, repoParts[0], repoParts[1], pull.number, github.COMMENTS.NO_BUG_FOUND);
+    }
     debug('Bug ID not found.');
     return;
   }

--- a/routes/pull_request.js
+++ b/routes/pull_request.js
@@ -51,7 +51,9 @@ module.exports = function(runtime) {
 
     // Validate that we have a bug number formatted to: "Bug xxxx - "
     // For now allow preceding characters to allow for reverts.
-    var bugId = yield validator.pullRequestHasBug(runtime, pull);
+    // Only adds a warning message to new PRs, to stop comment spam.
+    var addComment = (detail.action === "opened")
+    var bugId = yield validator.pullRequestHasBug(runtime, pull, addComment);
     if (!bugId) {
       return;
     }


### PR DESCRIPTION
Previously if a PR was missing a bug number from it's title, upon every PR change/event Autolander would spam the PR with a comment saying:

> Autolander could not find a bug number in your pull request title. All pull requests should be in the format of: Bug [number] - [description].

Rather than trying to scrape a PR's comments to see if a warning has already been left, it's much easier to only leave a warning when the PR is first created. It's highly unlikely that someone would add a bug number initially and then remove it later.