### PR TITLE
Bug 1278997 - Skip creating an integration branch if no taskgraph

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -62,9 +62,6 @@ exports.addComment = function * (runtime, user, repo, number, comment) {
  * @param {Object} pull
  */
 exports.integratePullRequest = function * (runtime, bugId, pull) {
-  yield exports.maybeCreateIntegrationBranch(runtime, pull);
-
-  var branchName = 'integration-' + pull.base.ref;
   var repoParts = pull.base.repo.full_name.split('/');
 
   // Do not process this bug if we are currently integrating it.
@@ -74,8 +71,24 @@ exports.integratePullRequest = function * (runtime, bugId, pull) {
     return;
   }
 
+  // If there is *no* taskgraph in the base repository, we auto-land straight away.
+  var taskgraphContent;
+  try {
+    taskgraphContent = yield fetchContent(runtime, repoParts[0], repoParts[1], pull.base.ref, 'taskgraph.json');
+  } catch(e) {
+    // Error loading taskgraph content.
+    taskgraphContent = false;
+  }
+  if (!taskgraphContent) {
+    yield bugzilla.mergePullRequest(runtime, bugId, pull, pull.base.ref);
+    return;
+  }
+
   // A reference to the merge to the integration branch.
   var integrationMerge;
+  var branchName = 'integration-' + pull.base.ref;
+
+  yield exports.maybeCreateIntegrationBranch(runtime, pull);
 
   try {
     var merge = thunkify(runtime.githubApi.repos.merge.bind(runtime.githubApi.repos));
@@ -119,19 +132,6 @@ exports.integratePullRequest = function * (runtime, bugId, pull) {
       comment: pull.html_url + '\n\n' + exports.COMMENTS.NON_INTEGRABLE
     });
 
-    return;
-  }
-
-  // If there is *no* taskgraph in the base repository, we auto-land.
-  var taskgraphContent;
-  try {
-    taskgraphContent = yield fetchContent(runtime, repoParts[0], repoParts[1], pull.base.ref, 'taskgraph.json');
-  } catch(e) {
-    // Error loading taskgraph content.
-    taskgraphContent = false;
-  }
-  if (!taskgraphContent) {
-    yield bugzilla.mergePullRequest(runtime, bugId, pull, pull.base.ref);
     return;
   }
 


### PR DESCRIPTION
The integration branch is unused if not scheduling jobs, so the check for a taskgraph.json file should be performed before creating the branch and not after.
